### PR TITLE
Setup volta

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ runs:
       with:
         cache: 'pnpm'
         node-version: ${{ inputs.node-version }}
+    - uses: volta-cli/action@v4
+      with:
+        node-version: ${{ inputs.node-version }}
       env:
         VOLTA_FEATURE_PNPM: 1
     - name: 'Install dependencies'

--- a/action.yml
+++ b/action.yml
@@ -36,12 +36,15 @@ runs:
       with:
         cache: 'pnpm'
         node-version: ${{ inputs.node-version }}
+      env:
+        VOLTA_FEATURE_PNPM: 1
     - name: 'Install dependencies'
       shell: 'bash'
+      env:
+        VOLTA_FEATURE_PNPM: 1  
       run: |
         if [[ "${{ inputs.no-lockfile }}" == "true" ]]; then 
           echo "Detected option --no-lockfile. Lockfile will be deleted before install."
           rm -f pnpm-lock.yaml
         fi
-
         pnpm install ${{ inputs.args }}


### PR DESCRIPTION
This'll need thorough testing, because the volta action is meant to replace setup-node.

But:
 - https://github.com/volta-cli/action/issues/121
 - https://github.com/volta-cli/action/issues/27
 
 The volta action may not have sufficient caching for workflows trying to be _most optimized_.
 
 
 To test this action out, replace:
 ```diff
 -- uses: NullVoxPopuli/action-setup-pnpm@v2
 +- uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
 ```
 
 In neovim, do it all in one go with a `:` command
```
%s/action-setup-pnpm@\(.*\)/action-setup-pnpm@NullVoxPopuli-patch-1/g
```
and to revert
```
%s/action-setup-pnpm@\(.*\)/action-setup-pnpm@v2/g
```