### PR TITLE
expose node-registry-url argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Allows changing the `node-version` passed to `actions/setup-node`.
     node-version: 18
 ```
 
+### `node-registry-url`
+
+Allows changing the `registry-url` passed to `actions/setup-node`.
+
+```yaml
+- uses: NullVoxPopuli/action-setup-pnpm@v2
+  with:
+    node-registry-url: "https://registry.npmjs.org"
+```
+
 ### `pnpm-version`
 
 Allows changing the `pnpm-version` passed to `pnpm/action-setup`.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   node-version:
     description: "Override the default node version, or override what is specified in your project's volta config"
     required: false
+  node-registry-url:
+    description: "Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
+    required: false
+    default: ''
   pnpm-version:
     description: 'Override the default pnpm version, which defaults to the latest 8.x'
     required: false
@@ -107,6 +111,7 @@ runs:
       with:
         cache: 'pnpm'
         node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.node-registry-url }}
     - name: 'Install dependencies'
       shell: 'bash'
       run: |


### PR DESCRIPTION
This would allow the action consumers to pass a custom registry-url (and set up auth) 