### PR TITLE
pass args to pnpm/action-setup instead of handling them here

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,12 +98,19 @@ runs:
         echo "version=$__resolved_version__"  >> $GITHUB_OUTPUT
 
 
+    - name: 'Remove lockfile'
+      shell: 'bash'
+      run: |
+        echo "Detected option --no-lockfile. Lockfile will be deleted before install."
+        rm -f pnpm-lock.yaml
+      if: ${{ inputs.no-lockfile == 'true' }}
     - name: 'Install pnpm'
       # this action aliases the major (via branch) to the latest full version
       # https://github.com/pnpm/action-setup/branches/all
       uses: pnpm/action-setup@v2
       with:
         version: ${{ steps.resolved-pnpm.outputs.version }}
+        run_install: "{ args: ['${{ inputs.args }}'] }"
     - name: 'Setup node and the cache for pnpm'
       # this action aliases the major to the latest full version 
       # https://github.com/actions/setup-node/tags
@@ -112,12 +119,3 @@ runs:
         cache: 'pnpm'
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.node-registry-url }}
-    - name: 'Install dependencies'
-      shell: 'bash'
-      run: |
-        if [[ "${{ inputs.no-lockfile }}" == "true" ]]; then 
-          echo "Detected option --no-lockfile. Lockfile will be deleted before install."
-          rm -f pnpm-lock.yaml
-        fi
-
-        pnpm install ${{ inputs.args }}


### PR DESCRIPTION
This MR pass directly pnpm install's args to the original pnpm action as it already handled from there with the `run_install` input.

(please ignore changes on ci.yml, it's just to test regressions)